### PR TITLE
Add .gitignore to exclude unnecessary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,135 @@
+# Created by https://www.toptal.com/developers/gitignore/api/macos,linux,windows,ruby
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,linux,windows,ruby
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Ruby ###
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,linux,windows,ruby


### PR DESCRIPTION
# 요약
불필요한 파일과 디렉터리가 버전 관리에 포함되지 않도록 ⁠.gitignore 파일을 추가했습니다.

## 상세 내용
* 저장소 루트 경로에 ⁠.gitignore 파일을 생성했습니다. 
* 다음과 같은 파일 및 디렉터리를 무시하도록 설정했습니다:
* IDE/에디터 설정 파일 (예: ⁠.vscode/, ⁠.idea/) 
* 운영체제에서 생성하는 파일 (예: ⁠Thumbs.db, ⁠.DS_Store) 
* 의존성 디렉터리 (예: ⁠node_modules/, ⁠venv/) 
* 빌드 및 로그 파일 (예: ⁠dist/, ⁠build/, ⁠*.log) 	
* 저장소를 깔끔하게 유지하고, 로컬 또는 민감한 파일이 실수로 커밋되는 것을 방지합니다.

## 도입 배경
* 불필요한 파일이 Git에 추적되는 것을 방지합니다. 
* 에디터나 환경별 파일로 인한 머지 충돌을 줄여 협업을 원활하게 합니다. 
* 저장소의 용량을 효율적으로 관리할 수 있습니다.